### PR TITLE
feat - 온보딩 페이지 UI 업데이트

### DIFF
--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -83,7 +83,7 @@ export default function ProgressScreen() {
         ]
       );
     },
-    [removePracticeHistoryEntry]
+    []
   );
   const handleDeleteAll = useCallback(() => {
     if (history.length === 0) return;
@@ -103,7 +103,7 @@ export default function ProgressScreen() {
         },
       ]
     );
-  }, [clearPracticeHistory, history.length]);
+  }, [history.length]);
 
   return (
     <SafeAreaView className="flex-1 bg-white">

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -2,6 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { router } from "expo-router";
 import { useEffect, useRef, useState } from "react";
 import {
+  Animated,
   Dimensions,
   FlatList,
   NativeScrollEvent,
@@ -26,6 +27,7 @@ export default function OnboardingScreen() {
   const [listReady, setListReady] = useState(false);
   const [hasAutoScrolled, setHasAutoScrolled] = useState(false);
   const listRef = useRef<FlatList<(typeof LEVEL_OPTIONS)[number]>>(null);
+  const scrollX = useRef(new Animated.Value(0)).current;
   const screenWidth = Dimensions.get("window").width;
   const cardWidth = screenWidth * 0.65;
   const cardHeight = 320;
@@ -133,115 +135,156 @@ export default function OnboardingScreen() {
         </View>
 
         <View className="flex-1 justify-center">
-          <FlatList
-            ref={listRef}
-            horizontal
-            data={LEVEL_OPTIONS}
-            keyExtractor={(item) => item.id}
-            showsHorizontalScrollIndicator={false}
-            snapToInterval={snapInterval}
-            decelerationRate="fast"
-            bounces={true}
-            onLayout={(event) => {
-              setListWidth(event.nativeEvent.layout.width);
-              setListReady(true);
-            }}
-            onMomentumScrollEnd={handleMomentumScrollEnd}
-            onScrollToIndexFailed={(info) => {
-              setTimeout(() => {
-                listRef.current?.scrollToIndex({
-                  index: info.index,
-                  animated: false,
-                  viewPosition: 0.5,
-                });
-              }, 50);
-            }}
-            style={{ height: cardHeight }}
-            contentContainerStyle={{
-              paddingHorizontal: sidePadding,
-            }}
-            ItemSeparatorComponent={() => <View style={{ width: cardGap }} />}
-            getItemLayout={(_, index) => ({
-              length: snapInterval,
-              offset: sidePadding + snapInterval * index,
-              index,
-            })}
-            renderItem={({ item, index }) => {
-              const isActive = item.id === selectedLevel;
+          <View className="items-center">
+            <FlatList
+              ref={listRef}
+              horizontal
+              data={LEVEL_OPTIONS}
+              keyExtractor={(item) => item.id}
+              showsHorizontalScrollIndicator={false}
+              snapToInterval={snapInterval}
+              decelerationRate="fast"
+              bounces={true}
+              onLayout={(event) => {
+                setListWidth(event.nativeEvent.layout.width);
+                setListReady(true);
+              }}
+              onMomentumScrollEnd={handleMomentumScrollEnd}
+              onScroll={Animated.event(
+                [{ nativeEvent: { contentOffset: { x: scrollX } } }],
+                { useNativeDriver: false },
+              )}
+              scrollEventThrottle={16}
+              onScrollToIndexFailed={(info) => {
+                setTimeout(() => {
+                  listRef.current?.scrollToIndex({
+                    index: info.index,
+                    animated: false,
+                    viewPosition: 0.5,
+                  });
+                }, 50);
+              }}
+              style={{ height: cardHeight, flexGrow: 0 }}
+              contentContainerStyle={{
+                paddingHorizontal: sidePadding,
+              }}
+              ItemSeparatorComponent={() => <View style={{ width: cardGap }} />}
+              getItemLayout={(_, index) => ({
+                length: snapInterval,
+                offset: sidePadding + snapInterval * index,
+                index,
+              })}
+              renderItem={({ item, index }) => {
+                const isActive = item.id === selectedLevel;
 
-              return (
-                <View
-                  className={`relative rounded-3xl border p-12 ${
-                    isActive
-                      ? "border-primary-500 bg-primary-100"
-                      : "border-gray-200 bg-white"
-                  }`}
-                  style={{
-                    width: cardWidth,
-                    height: cardHeight,
-                  }}
-                >
-                  {/* ✅ 텍스트를 수직 중앙으로 */}
-                  <View className="flex-1 items-center justify-center gap-6">
-                    <Text
-                      className={`text-center text-5xl font-semibold ${
-                        isActive ? "text-primary-600" : "text-gray-900"
-                      }`}
-                    >
-                      {item.title}
-                    </Text>
-
-                    <Text
-                      className={`text-center text-lg leading-6 ${
-                        isActive ? "text-primary-600" : "text-gray-600"
-                      }`}
-                    >
-                      {item.description}
-                    </Text>
-                  </View>
-
-                  {/* ✅ 버튼은 아래 */}
-                  <View className="w-full items-center  ">
-                    <TouchableOpacity
-                      activeOpacity={0.9}
-                      onPress={() => handleConfirmLevel(index)}
-                      className={`rounded-full w-full py-3 ${
-                        isActive
-                          ? "bg-primary-600"
-                          : "border border-primary-400 bg-white"
-                      }`}
-                    >
+                return (
+                  <View
+                    className={`relative rounded-3xl border p-12 ${
+                      isActive
+                        ? "border-primary-500 bg-primary-100"
+                        : "border-gray-200 bg-white"
+                    }`}
+                    style={{
+                      width: cardWidth,
+                      height: cardHeight,
+                    }}
+                  >
+                    {/* ✅ 텍스트를 수직 중앙으로 */}
+                    <View className="flex-1 items-center justify-center gap-6">
                       <Text
-                        className={`text-center text-sm font-semibold ${
-                          isActive ? "text-white" : "text-primary-600"
+                        className={`text-center text-5xl font-semibold ${
+                          isActive ? "text-primary-600" : "text-gray-900"
                         }`}
                       >
-                        {isActive ? "선택 완료" : "선택"}
+                        {item.title}
                       </Text>
-                    </TouchableOpacity>
+
+                      <Text
+                        className={`text-center text-lg leading-6 ${
+                          isActive ? "text-primary-600" : "text-gray-600"
+                        }`}
+                      >
+                        {item.description}
+                      </Text>
+                    </View>
+
+                    {/* ✅ 버튼은 아래 */}
+                    <View className="w-full items-center  ">
+                      <TouchableOpacity
+                        activeOpacity={0.9}
+                        onPress={() => handleConfirmLevel(index)}
+                        className={`rounded-full w-full py-3 ${
+                          isActive
+                            ? "bg-primary-600"
+                            : "border border-primary-400 bg-white"
+                        }`}
+                      >
+                        <Text
+                          className={`text-center text-sm font-semibold ${
+                            isActive ? "text-white" : "text-primary-600"
+                          }`}
+                        >
+                          {isActive ? "선택 완료" : "선택"}
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
                   </View>
-                </View>
-              );
-            }}
-          />
+                );
+              }}
+            />
 
-          <View className="mt-4 flex-row items-center justify-center">
-            {LEVEL_OPTIONS.map((level, index) => {
-              const isActive = index === currentIndex;
+            <View className="mt-4 flex-row items-center justify-center">
+              {LEVEL_OPTIONS.map((level, index) => {
+                const inputRange = [
+                  (index - 1) * snapInterval,
+                  index * snapInterval,
+                  (index + 1) * snapInterval,
+                ];
+                const scale = scrollX.interpolate({
+                  inputRange,
+                  outputRange: [0.6, 1.4, 0.6],
+                  extrapolate: "clamp",
+                });
+                const opacity = scrollX.interpolate({
+                  inputRange,
+                  outputRange: [0.3, 1, 0.3],
+                  extrapolate: "clamp",
+                });
 
-              return (
-                <View
-                  key={level.id}
-                  className={`mx-1 rounded-full ${
-                    isActive ? "bg-primary-600" : "bg-gray-300"
-                  }`}
-                  style={{
-                    width: isActive ? 10 : 6,
-                    height: isActive ? 10 : 6,
-                  }}
-                />
-              );
-            })}
+                return (
+                  <View
+                    key={level.id}
+                    style={{
+                      width: 12,
+                      height: 12,
+                      marginHorizontal: 4,
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <View
+                      style={{
+                        width: 6,
+                        height: 6,
+                        borderRadius: 3,
+                        backgroundColor: "#D1D5DB",
+                      }}
+                    />
+                    <Animated.View
+                      style={{
+                        position: "absolute",
+                        width: 6,
+                        height: 6,
+                        borderRadius: 3,
+                        backgroundColor: "#512FE2",
+                        opacity,
+                        transform: [{ scale }],
+                      }}
+                    />
+                  </View>
+                );
+              })}
+            </View>
           </View>
         </View>
       </ScrollView>

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -1,122 +1,17 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
+// app/onboarding.tsx (or 기존 파일)
+import { LevelCarousel } from "@/components/onboarding/carousel/level-carousel";
+import { useTargetLevel } from "@/hooks/onboarding/use-target-level";
 import { router } from "expo-router";
-import { useEffect, useRef, useState } from "react";
-import {
-  Animated,
-  Dimensions,
-  FlatList,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  ScrollView,
-  Text,
-  TouchableOpacity,
-  View,
-} from "react-native";
-
-import {
-  LEVEL_OPTIONS,
-  LevelId,
-  TARGET_LEVEL_STORAGE_KEY,
-} from "@/constants/opic";
+import { ScrollView, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function OnboardingScreen() {
-  const [selectedLevel, setSelectedLevel] = useState<LevelId | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [listReady, setListReady] = useState(false);
-  const [hasAutoScrolled, setHasAutoScrolled] = useState(false);
-  const listRef = useRef<FlatList<(typeof LEVEL_OPTIONS)[number]>>(null);
-  const scrollX = useRef(new Animated.Value(0)).current;
-  const screenWidth = Dimensions.get("window").width;
-  const cardWidth = screenWidth * 0.65;
-  const cardHeight = 320;
-  const cardGap = 16;
-  const snapInterval = cardWidth + cardGap;
-  const [listWidth, setListWidth] = useState(screenWidth);
-  const sidePadding = Math.max(0, (listWidth - cardWidth) / 2);
-
-  useEffect(() => {
-    const loadSavedLevel = async () => {
-      try {
-        const storedLevel = await AsyncStorage.getItem(
-          TARGET_LEVEL_STORAGE_KEY,
-        );
-
-        if (
-          storedLevel &&
-          LEVEL_OPTIONS.some((option) => option.id === storedLevel)
-        ) {
-          setSelectedLevel(storedLevel as LevelId);
-        }
-      } catch (error) {
-        console.error("Failed to load saved target level", error);
-      }
-    };
-
-    loadSavedLevel();
-  }, []);
-
-  useEffect(() => {
-    if (!selectedLevel || hasAutoScrolled || !listReady) return;
-
-    const index = LEVEL_OPTIONS.findIndex(
-      (option) => option.id === selectedLevel,
-    );
-
-    if (index < 0) return;
-
-    setCurrentIndex(index);
-    listRef.current?.scrollToIndex({
-      index,
-      animated: false,
-      viewPosition: 0.5,
-    });
-    setHasAutoScrolled(true);
-  }, [selectedLevel, hasAutoScrolled, listReady]);
+  const { selectedLevel, setSelectedLevel, save, isSaving } = useTargetLevel();
 
   const handleContinue = async () => {
     if (!selectedLevel || isSaving) return;
-
-    try {
-      setIsSaving(true);
-      await AsyncStorage.setItem(TARGET_LEVEL_STORAGE_KEY, selectedLevel);
-      router.replace("/");
-    } catch (error) {
-      console.error("Failed to save target level", error);
-      setIsSaving(false);
-    }
-  };
-
-  const handleConfirmLevel = (index: number) => {
-    const level = LEVEL_OPTIONS[index];
-
-    if (!level) return;
-
-    if (selectedLevel === level.id) {
-      handleContinue();
-      return;
-    }
-
-    setSelectedLevel(level.id);
-    setCurrentIndex(index);
-    if (index !== currentIndex) {
-      listRef.current?.scrollToIndex({
-        index,
-        animated: true,
-        viewPosition: 0.5,
-      });
-    }
-  };
-
-  const handleMomentumScrollEnd = (
-    event: NativeSyntheticEvent<NativeScrollEvent>,
-  ) => {
-    const offsetX = event.nativeEvent.contentOffset.x;
-    const index = Math.round(offsetX / snapInterval);
-    const clampedIndex = Math.max(0, Math.min(index, LEVEL_OPTIONS.length - 1));
-
-    setCurrentIndex(clampedIndex);
+    await save(selectedLevel);
+    router.replace("/");
   };
 
   return (
@@ -134,158 +29,12 @@ export default function OnboardingScreen() {
           </Text>
         </View>
 
-        <View className="flex-1 justify-center ">
-          <View className="items-center gap-8">
-            <FlatList
-              ref={listRef}
-              horizontal
-              data={LEVEL_OPTIONS}
-              keyExtractor={(item) => item.id}
-              showsHorizontalScrollIndicator={false}
-              snapToInterval={snapInterval}
-              decelerationRate="fast"
-              bounces={true}
-              onLayout={(event) => {
-                setListWidth(event.nativeEvent.layout.width);
-                setListReady(true);
-              }}
-              onMomentumScrollEnd={handleMomentumScrollEnd}
-              onScroll={Animated.event(
-                [{ nativeEvent: { contentOffset: { x: scrollX } } }],
-                { useNativeDriver: false },
-              )}
-              scrollEventThrottle={16}
-              onScrollToIndexFailed={(info) => {
-                setTimeout(() => {
-                  listRef.current?.scrollToIndex({
-                    index: info.index,
-                    animated: false,
-                    viewPosition: 0.5,
-                  });
-                }, 50);
-              }}
-              style={{ height: cardHeight, flexGrow: 0 }}
-              contentContainerStyle={{
-                paddingHorizontal: sidePadding,
-              }}
-              ItemSeparatorComponent={() => <View style={{ width: cardGap }} />}
-              getItemLayout={(_, index) => ({
-                length: snapInterval,
-                offset: sidePadding + snapInterval * index,
-                index,
-              })}
-              renderItem={({ item, index }) => {
-                const isActive = item.id === selectedLevel;
-
-                return (
-                  <View
-                    className={`relative rounded-3xl border p-12 ${
-                      isActive
-                        ? "border-primary-500 bg-primary-100"
-                        : "border-gray-200 bg-white"
-                    }`}
-                    style={{
-                      width: cardWidth,
-                      height: cardHeight,
-                    }}
-                  >
-                    {/* ✅ 텍스트를 수직 중앙으로 */}
-                    <View className="flex-1 items-center justify-center gap-6">
-                      <Text
-                        className={`text-center text-5xl font-semibold ${
-                          isActive ? "text-primary-600" : "text-gray-900"
-                        }`}
-                      >
-                        {item.title}
-                      </Text>
-
-                      <Text
-                        className={`text-center text-lg leading-6 ${
-                          isActive ? "text-primary-600" : "text-gray-600"
-                        }`}
-                      >
-                        {item.description}
-                      </Text>
-                    </View>
-
-                    {/* ✅ 버튼은 아래 */}
-                    <View className="w-full items-center  ">
-                      <TouchableOpacity
-                        activeOpacity={0.9}
-                        onPress={() => handleConfirmLevel(index)}
-                        className={`rounded-full w-full py-3 ${
-                          isActive
-                            ? "bg-primary-600"
-                            : "border border-primary-400 bg-white"
-                        }`}
-                      >
-                        <Text
-                          className={`text-center text-sm font-semibold ${
-                            isActive ? "text-white" : "text-primary-600"
-                          }`}
-                        >
-                          {isActive ? "선택 완료" : "선택"}
-                        </Text>
-                      </TouchableOpacity>
-                    </View>
-                  </View>
-                );
-              }}
-            />
-
-            <View className="mt-4 flex-row items-center justify-center">
-              {LEVEL_OPTIONS.map((level, index) => {
-                const inputRange = [
-                  (index - 1) * snapInterval,
-                  index * snapInterval,
-                  (index + 1) * snapInterval,
-                ];
-                const scale = scrollX.interpolate({
-                  inputRange,
-                  outputRange: [0.6, 1.4, 0.6],
-                  extrapolate: "clamp",
-                });
-                const opacity = scrollX.interpolate({
-                  inputRange,
-                  outputRange: [0.3, 1, 0.3],
-                  extrapolate: "clamp",
-                });
-
-                return (
-                  <View
-                    key={level.id}
-                    style={{
-                      width: 12,
-                      height: 12,
-                      marginHorizontal: 4,
-                      alignItems: "center",
-                      justifyContent: "center",
-                    }}
-                  >
-                    <View
-                      style={{
-                        width: 6,
-                        height: 6,
-                        borderRadius: 3,
-                        backgroundColor: "#D1D5DB",
-                      }}
-                    />
-                    <Animated.View
-                      style={{
-                        position: "absolute",
-                        width: 6,
-                        height: 6,
-                        borderRadius: 3,
-                        backgroundColor: "#512FE2",
-                        opacity,
-                        transform: [{ scale }],
-                      }}
-                    />
-                  </View>
-                );
-              })}
-            </View>
-          </View>
+        <View className="flex-1 justify-center">
+          <LevelCarousel
+            selectedLevel={selectedLevel}
+            onSelect={setSelectedLevel}
+            onDoubleConfirm={handleContinue}
+          />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -28,7 +28,7 @@ export default function OnboardingScreen() {
   const listRef = useRef<FlatList<(typeof LEVEL_OPTIONS)[number]>>(null);
   const screenWidth = Dimensions.get("window").width;
   const cardWidth = screenWidth * 0.65;
-  const cardHeight = 340;
+  const cardHeight = 320;
   const cardGap = 16;
   const snapInterval = cardWidth + cardGap;
   const [listWidth, setListWidth] = useState(screenWidth);
@@ -171,7 +171,7 @@ export default function OnboardingScreen() {
 
               return (
                 <View
-                  className={`relative rounded-3xl border p-5 ${
+                  className={`relative rounded-3xl border p-12 ${
                     isActive
                       ? "border-primary-500 bg-primary-100"
                       : "border-gray-200 bg-white"
@@ -181,40 +181,44 @@ export default function OnboardingScreen() {
                     height: cardHeight,
                   }}
                 >
-                  <View className="flex-1 items-center justify-center">
+                  {/* ✅ 텍스트를 수직 중앙으로 */}
+                  <View className="flex-1 items-center justify-center gap-6">
                     <Text
-                      className={`text-center text-3xl font-semibold ${
+                      className={`text-center text-5xl font-semibold ${
                         isActive ? "text-primary-600" : "text-gray-900"
                       }`}
                     >
                       {item.title}
                     </Text>
+
                     <Text
-                      className={`mt-4 text-center text-sm leading-6 ${
+                      className={`text-center text-lg leading-6 ${
                         isActive ? "text-primary-600" : "text-gray-600"
                       }`}
                     >
                       {item.description}
                     </Text>
-                    <View className="mt-auto w-full items-center">
-                      <TouchableOpacity
-                        activeOpacity={0.9}
-                        onPress={() => handleConfirmLevel(index)}
-                        className={`rounded-full px-8 py-2.5 ${
-                          isActive
-                            ? "bg-primary-600"
-                            : "border border-primary-400 bg-white"
+                  </View>
+
+                  {/* ✅ 버튼은 아래 */}
+                  <View className="w-full items-center  ">
+                    <TouchableOpacity
+                      activeOpacity={0.9}
+                      onPress={() => handleConfirmLevel(index)}
+                      className={`rounded-full w-full py-3 ${
+                        isActive
+                          ? "bg-primary-600"
+                          : "border border-primary-400 bg-white"
+                      }`}
+                    >
+                      <Text
+                        className={`text-center text-sm font-semibold ${
+                          isActive ? "text-white" : "text-primary-600"
                         }`}
                       >
-                        <Text
-                          className={`text-center text-sm font-semibold ${
-                            isActive ? "text-white" : "text-primary-600"
-                          }`}
-                        >
-                          {isActive ? "선택 완료" : "선택"}
-                        </Text>
-                      </TouchableOpacity>
-                    </View>
+                        {isActive ? "선택 완료" : "선택"}
+                      </Text>
+                    </TouchableOpacity>
                   </View>
                 </View>
               );

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -125,7 +125,7 @@ export default function OnboardingScreen() {
         contentContainerClassName="flex-grow px-6 pb-12 pt-10"
         bounces={false}
       >
-        <View className="my-12">
+        <View className="mt-12">
           <Text className="text-center text-3xl font-semibold text-gray-900">
             목표 오픽 등급을 선택하세요
           </Text>
@@ -134,8 +134,8 @@ export default function OnboardingScreen() {
           </Text>
         </View>
 
-        <View className="flex-1 justify-center">
-          <View className="items-center">
+        <View className="flex-1 justify-center ">
+          <View className="items-center gap-8">
             <FlatList
               ref={listRef}
               horizontal

--- a/app/onboarding/index.tsx
+++ b/app/onboarding/index.tsx
@@ -1,7 +1,16 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { router } from "expo-router";
-import { useEffect, useState } from "react";
-import { ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { useEffect, useRef, useState } from "react";
+import {
+  Dimensions,
+  FlatList,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 
 import {
   LEVEL_OPTIONS,
@@ -13,12 +22,23 @@ import { SafeAreaView } from "react-native-safe-area-context";
 export default function OnboardingScreen() {
   const [selectedLevel, setSelectedLevel] = useState<LevelId | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [listReady, setListReady] = useState(false);
+  const [hasAutoScrolled, setHasAutoScrolled] = useState(false);
+  const listRef = useRef<FlatList<(typeof LEVEL_OPTIONS)[number]>>(null);
+  const screenWidth = Dimensions.get("window").width;
+  const cardWidth = screenWidth * 0.65;
+  const cardHeight = 340;
+  const cardGap = 16;
+  const snapInterval = cardWidth + cardGap;
+  const [listWidth, setListWidth] = useState(screenWidth);
+  const sidePadding = Math.max(0, (listWidth - cardWidth) / 2);
 
   useEffect(() => {
     const loadSavedLevel = async () => {
       try {
         const storedLevel = await AsyncStorage.getItem(
-          TARGET_LEVEL_STORAGE_KEY
+          TARGET_LEVEL_STORAGE_KEY,
         );
 
         if (
@@ -35,6 +55,24 @@ export default function OnboardingScreen() {
     loadSavedLevel();
   }, []);
 
+  useEffect(() => {
+    if (!selectedLevel || hasAutoScrolled || !listReady) return;
+
+    const index = LEVEL_OPTIONS.findIndex(
+      (option) => option.id === selectedLevel,
+    );
+
+    if (index < 0) return;
+
+    setCurrentIndex(index);
+    listRef.current?.scrollToIndex({
+      index,
+      animated: false,
+      viewPosition: 0.5,
+    });
+    setHasAutoScrolled(true);
+  }, [selectedLevel, hasAutoScrolled, listReady]);
+
   const handleContinue = async () => {
     if (!selectedLevel || isSaving) return;
 
@@ -48,82 +86,159 @@ export default function OnboardingScreen() {
     }
   };
 
+  const handleConfirmLevel = (index: number) => {
+    const level = LEVEL_OPTIONS[index];
+
+    if (!level) return;
+
+    if (selectedLevel === level.id) {
+      handleContinue();
+      return;
+    }
+
+    setSelectedLevel(level.id);
+    setCurrentIndex(index);
+    if (index !== currentIndex) {
+      listRef.current?.scrollToIndex({
+        index,
+        animated: true,
+        viewPosition: 0.5,
+      });
+    }
+  };
+
+  const handleMomentumScrollEnd = (
+    event: NativeSyntheticEvent<NativeScrollEvent>,
+  ) => {
+    const offsetX = event.nativeEvent.contentOffset.x;
+    const index = Math.round(offsetX / snapInterval);
+    const clampedIndex = Math.max(0, Math.min(index, LEVEL_OPTIONS.length - 1));
+
+    setCurrentIndex(clampedIndex);
+  };
+
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-gray-50">
       <ScrollView
-        contentContainerClassName="flex-grow px-6 pb-10 pt-8"
+        contentContainerClassName="flex-grow px-6 pb-12 pt-10"
         bounces={false}
       >
-        <View className="mb-8">
-          <Text className="text-3xl font-semibold text-gray-900">
+        <View className="my-12">
+          <Text className="text-center text-3xl font-semibold text-gray-900">
             목표 오픽 등급을 선택하세요
           </Text>
-          <Text className="mt-3 text-base text-gray-600">
+          <Text className="mt-3 text-center text-base text-gray-600">
             선택한 목표는 이후 홈 화면에서 계속 확인할 수 있어요.
           </Text>
         </View>
 
-        <View className="-mx-2 flex-row flex-wrap">
-          {LEVEL_OPTIONS.map((level) => {
-            const isActive = level.id === selectedLevel;
+        <View className="flex-1 justify-center">
+          <FlatList
+            ref={listRef}
+            horizontal
+            data={LEVEL_OPTIONS}
+            keyExtractor={(item) => item.id}
+            showsHorizontalScrollIndicator={false}
+            snapToInterval={snapInterval}
+            decelerationRate="fast"
+            bounces={true}
+            onLayout={(event) => {
+              setListWidth(event.nativeEvent.layout.width);
+              setListReady(true);
+            }}
+            onMomentumScrollEnd={handleMomentumScrollEnd}
+            onScrollToIndexFailed={(info) => {
+              setTimeout(() => {
+                listRef.current?.scrollToIndex({
+                  index: info.index,
+                  animated: false,
+                  viewPosition: 0.5,
+                });
+              }, 50);
+            }}
+            style={{ height: cardHeight }}
+            contentContainerStyle={{
+              paddingHorizontal: sidePadding,
+            }}
+            ItemSeparatorComponent={() => <View style={{ width: cardGap }} />}
+            getItemLayout={(_, index) => ({
+              length: snapInterval,
+              offset: sidePadding + snapInterval * index,
+              index,
+            })}
+            renderItem={({ item, index }) => {
+              const isActive = item.id === selectedLevel;
 
-            return (
-              <View key={level.id} className="w-1/2 px-2">
-                <TouchableOpacity
-                  activeOpacity={0.9}
-                  onPress={() => setSelectedLevel(level.id)}
-                  className={`relative mb-4 rounded-2xl border p-4 ${
+              return (
+                <View
+                  className={`relative rounded-3xl border p-5 ${
                     isActive
-                      ? "border-primary-600 bg-primary-100"
+                      ? "border-primary-500 bg-primary-100"
                       : "border-gray-200 bg-white"
                   }`}
-                  style={{ height: 120 }}
+                  style={{
+                    width: cardWidth,
+                    height: cardHeight,
+                  }}
                 >
-                  <View
-                    className={`absolute right-3 top-3 h-5 w-5 rounded-full border-2 ${
-                      isActive ? "border-primary-600 bg-primary-600" : "border-gray-300"
-                    }`}
-                  />
-                  <Text
-                    className={`text-xl font-semibold ${
-                      isActive ? "text-primary-600" : "text-gray-900"
-                    }`}
-                  >
-                    {level.title}
-                  </Text>
-                  <Text
-                    className={`mt-2 text-sm leading-5 ${
-                      isActive ? "text-primary-600" : "text-gray-600"
-                    }`}
-                  >
-                    {level.description}
-                  </Text>
-                </TouchableOpacity>
-              </View>
-            );
-          })}
-        </View>
+                  <View className="flex-1 items-center justify-center">
+                    <Text
+                      className={`text-center text-3xl font-semibold ${
+                        isActive ? "text-primary-600" : "text-gray-900"
+                      }`}
+                    >
+                      {item.title}
+                    </Text>
+                    <Text
+                      className={`mt-4 text-center text-sm leading-6 ${
+                        isActive ? "text-primary-600" : "text-gray-600"
+                      }`}
+                    >
+                      {item.description}
+                    </Text>
+                    <View className="mt-auto w-full items-center">
+                      <TouchableOpacity
+                        activeOpacity={0.9}
+                        onPress={() => handleConfirmLevel(index)}
+                        className={`rounded-full px-8 py-2.5 ${
+                          isActive
+                            ? "bg-primary-600"
+                            : "border border-primary-400 bg-white"
+                        }`}
+                      >
+                        <Text
+                          className={`text-center text-sm font-semibold ${
+                            isActive ? "text-white" : "text-primary-600"
+                          }`}
+                        >
+                          {isActive ? "선택 완료" : "선택"}
+                        </Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                </View>
+              );
+            }}
+          />
 
-        <View className="mt-10">
-          <TouchableOpacity
-            activeOpacity={selectedLevel ? 0.8 : 1}
-            onPress={handleContinue}
-            disabled={!selectedLevel || isSaving}
-            className={`rounded-xl p-4 ${
-              selectedLevel ? "bg-primary-600" : "bg-gray-200"
-            }`}
-          >
-            <Text
-              className={`text-center text-lg font-semibold ${
-                selectedLevel ? "text-white" : "text-gray-500"
-              }`}
-            >
-              {isSaving ? "저장 중..." : "메인 화면으로 이동"}
-            </Text>
-          </TouchableOpacity>
-          <Text className="mt-3 text-center text-xs text-gray-500">
-            언제든 설정에서 목표 등급을 다시 선택할 수 있어요.
-          </Text>
+          <View className="mt-4 flex-row items-center justify-center">
+            {LEVEL_OPTIONS.map((level, index) => {
+              const isActive = index === currentIndex;
+
+              return (
+                <View
+                  key={level.id}
+                  className={`mx-1 rounded-full ${
+                    isActive ? "bg-primary-600" : "bg-gray-300"
+                  }`}
+                  style={{
+                    width: isActive ? 10 : 6,
+                    height: isActive ? 10 : 6,
+                  }}
+                />
+              );
+            })}
+          </View>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/components/onboarding/carousel/level-card.tsx
+++ b/components/onboarding/carousel/level-card.tsx
@@ -1,0 +1,66 @@
+import { Text, TouchableOpacity, View } from "react-native";
+
+type Props = {
+  title: string;
+  description: string;
+  isActive: boolean;
+  onPress: () => void;
+  width: number;
+  height: number;
+};
+
+export function LevelCard({
+  title,
+  description,
+  isActive,
+  onPress,
+  width,
+  height,
+}: Props) {
+  return (
+    <View
+      className={`relative rounded-3xl border p-12 ${
+        isActive
+          ? "border-primary-500 bg-primary-100"
+          : "border-gray-200 bg-white"
+      }`}
+      style={{ width, height }}
+    >
+      <View className="flex-1 items-center justify-center gap-6">
+        <Text
+          className={`text-center text-5xl font-semibold ${
+            isActive ? "text-primary-600" : "text-gray-900"
+          }`}
+        >
+          {title}
+        </Text>
+
+        <Text
+          className={`text-center text-lg leading-6 ${
+            isActive ? "text-primary-600" : "text-gray-600"
+          }`}
+        >
+          {description}
+        </Text>
+      </View>
+
+      <View className="w-full items-center">
+        <TouchableOpacity
+          activeOpacity={0.9}
+          onPress={onPress}
+          className={`w-full rounded-full py-3 ${
+            isActive ? "bg-primary-600" : "border border-primary-400 bg-white"
+          }`}
+        >
+          <Text
+            className={`text-center text-sm font-semibold ${
+              isActive ? "text-white" : "text-primary-600"
+            }`}
+          >
+            {isActive ? "선택 완료" : "선택"}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/components/onboarding/carousel/level-carousel.tsx
+++ b/components/onboarding/carousel/level-carousel.tsx
@@ -15,6 +15,7 @@ export function LevelCarousel({
   onSelect,
   onDoubleConfirm,
 }: Props) {
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [listReady, setListReady] = useState(false);
   const [hasAutoScrolled, setHasAutoScrolled] = useState(false);
 
@@ -37,6 +38,7 @@ export function LevelCarousel({
     const index = LEVEL_OPTIONS.findIndex((o) => o.id === selectedLevel);
     if (index < 0) return;
 
+    setCurrentIndex(index);
     listRef.current?.scrollToIndex({
       index,
       animated: false,
@@ -57,11 +59,25 @@ export function LevelCarousel({
 
     onSelect(level.id);
 
+    if (index === currentIndex) {
+      return;
+    }
+
     listRef.current?.scrollToIndex({
       index,
       animated: true,
       viewPosition: 0.5,
     });
+  };
+
+  const handleMomentumScrollEnd = (
+    event: { nativeEvent: { contentOffset: { x: number } } },
+  ) => {
+    const offsetX = event.nativeEvent.contentOffset.x;
+    const index = Math.round(offsetX / snapInterval);
+    const clampedIndex = Math.max(0, Math.min(index, LEVEL_OPTIONS.length - 1));
+
+    setCurrentIndex(clampedIndex);
   };
 
   return (
@@ -79,6 +95,7 @@ export function LevelCarousel({
           setListWidth(event.nativeEvent.layout.width);
           setListReady(true);
         }}
+        onMomentumScrollEnd={handleMomentumScrollEnd}
         onScroll={Animated.event(
           [{ nativeEvent: { contentOffset: { x: scrollX } } }],
           { useNativeDriver: false },

--- a/components/onboarding/carousel/level-carousel.tsx
+++ b/components/onboarding/carousel/level-carousel.tsx
@@ -1,0 +1,127 @@
+import { LEVEL_OPTIONS, LevelId } from "@/constants/opic";
+import { useEffect, useRef, useState } from "react";
+import { Animated, Dimensions, FlatList, View } from "react-native";
+import { LevelCard } from "./level-card";
+import { LevelIndicator } from "./level-indicator";
+
+type Props = {
+  selectedLevel: LevelId | null;
+  onSelect: (level: LevelId) => void;
+  onDoubleConfirm?: () => void; // 같은 레벨 다시 누르면 계속 진행 같은 용도
+};
+
+export function LevelCarousel({
+  selectedLevel,
+  onSelect,
+  onDoubleConfirm,
+}: Props) {
+  const [listReady, setListReady] = useState(false);
+  const [hasAutoScrolled, setHasAutoScrolled] = useState(false);
+
+  const listRef = useRef<FlatList<(typeof LEVEL_OPTIONS)[number]>>(null);
+  const scrollX = useRef(new Animated.Value(0)).current;
+
+  const screenWidth = Dimensions.get("window").width;
+  const cardWidth = screenWidth * 0.65;
+  const cardHeight = 320;
+  const cardGap = 16;
+  const snapInterval = cardWidth + cardGap;
+
+  const [listWidth, setListWidth] = useState(screenWidth);
+  const sidePadding = Math.max(0, (listWidth - cardWidth) / 2);
+
+  // ✅ 저장된 레벨이 있으면 해당 카드로 자동 이동
+  useEffect(() => {
+    if (!selectedLevel || hasAutoScrolled || !listReady) return;
+
+    const index = LEVEL_OPTIONS.findIndex((o) => o.id === selectedLevel);
+    if (index < 0) return;
+
+    listRef.current?.scrollToIndex({
+      index,
+      animated: false,
+      viewPosition: 0.5,
+    });
+
+    setHasAutoScrolled(true);
+  }, [selectedLevel, hasAutoScrolled, listReady]);
+
+  const handlePressCardButton = (index: number) => {
+    const level = LEVEL_OPTIONS[index];
+    if (!level) return;
+
+    if (selectedLevel === level.id) {
+      onDoubleConfirm?.();
+      return;
+    }
+
+    onSelect(level.id);
+
+    listRef.current?.scrollToIndex({
+      index,
+      animated: true,
+      viewPosition: 0.5,
+    });
+  };
+
+  return (
+    <View className="items-center gap-8">
+      <FlatList
+        ref={listRef}
+        horizontal
+        data={LEVEL_OPTIONS}
+        keyExtractor={(item) => item.id}
+        showsHorizontalScrollIndicator={false}
+        snapToInterval={snapInterval}
+        decelerationRate="fast"
+        bounces={true}
+        onLayout={(event) => {
+          setListWidth(event.nativeEvent.layout.width);
+          setListReady(true);
+        }}
+        onScroll={Animated.event(
+          [{ nativeEvent: { contentOffset: { x: scrollX } } }],
+          { useNativeDriver: false },
+        )}
+        scrollEventThrottle={16}
+        onScrollToIndexFailed={(info) => {
+          setTimeout(() => {
+            listRef.current?.scrollToIndex({
+              index: info.index,
+              animated: false,
+              viewPosition: 0.5,
+            });
+          }, 50);
+        }}
+        style={{ height: cardHeight, flexGrow: 0 }}
+        contentContainerStyle={{ paddingHorizontal: sidePadding }}
+        ItemSeparatorComponent={() => <View style={{ width: cardGap }} />}
+        getItemLayout={(_, index) => ({
+          length: snapInterval,
+          offset: sidePadding + snapInterval * index,
+          index,
+        })}
+        renderItem={({ item, index }) => {
+          const isActive = item.id === selectedLevel;
+
+          return (
+            <LevelCard
+              title={item.title}
+              description={item.description}
+              isActive={isActive}
+              width={cardWidth}
+              height={cardHeight}
+              onPress={() => handlePressCardButton(index)}
+            />
+          );
+        }}
+      />
+
+      <LevelIndicator
+        count={LEVEL_OPTIONS.length}
+        snapInterval={snapInterval}
+        scrollX={scrollX}
+      />
+    </View>
+  );
+}

--- a/components/onboarding/carousel/level-indicator.tsx
+++ b/components/onboarding/carousel/level-indicator.tsx
@@ -1,0 +1,66 @@
+import { Animated, View } from "react-native";
+
+type Props = {
+  count: number;
+  snapInterval: number;
+  scrollX: Animated.Value;
+};
+
+export function LevelIndicator({ count, snapInterval, scrollX }: Props) {
+  return (
+    <View className="mt-4 flex-row items-center justify-center">
+      {Array.from({ length: count }).map((_, index) => {
+        const inputRange = [
+          (index - 1) * snapInterval,
+          index * snapInterval,
+          (index + 1) * snapInterval,
+        ];
+
+        const scale = scrollX.interpolate({
+          inputRange,
+          outputRange: [0.6, 1.4, 0.6],
+          extrapolate: "clamp",
+        });
+
+        const opacity = scrollX.interpolate({
+          inputRange,
+          outputRange: [0.3, 1, 0.3],
+          extrapolate: "clamp",
+        });
+
+        return (
+          <View
+            key={index}
+            style={{
+              width: 12,
+              height: 12,
+              marginHorizontal: 4,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <View
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: 3,
+                backgroundColor: "#D1D5DB",
+              }}
+            />
+            <Animated.View
+              style={{
+                position: "absolute",
+                width: 6,
+                height: 6,
+                borderRadius: 3,
+                backgroundColor: "#512FE2",
+                opacity,
+                transform: [{ scale }],
+              }}
+            />
+          </View>
+        );
+      })}
+    </View>
+  );
+}

--- a/hooks/onboarding/use-target-level.ts
+++ b/hooks/onboarding/use-target-level.ts
@@ -1,0 +1,47 @@
+import {
+  LEVEL_OPTIONS,
+  LevelId,
+  TARGET_LEVEL_STORAGE_KEY,
+} from "@/constants/opic";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useEffect, useState } from "react";
+
+export function useTargetLevel() {
+  const [selectedLevel, setSelectedLevel] = useState<LevelId | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    const loadSavedLevel = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(TARGET_LEVEL_STORAGE_KEY);
+        if (stored && LEVEL_OPTIONS.some((o) => o.id === stored)) {
+          setSelectedLevel(stored as LevelId);
+        }
+      } catch (e) {
+        console.error("Failed to load saved target level", e);
+      }
+    };
+
+    loadSavedLevel();
+  }, []);
+
+  const save = async (level: LevelId) => {
+    if (isSaving) return;
+    try {
+      setIsSaving(true);
+      await AsyncStorage.setItem(TARGET_LEVEL_STORAGE_KEY, level);
+    } catch (e) {
+      console.error("Failed to save target level", e);
+      throw e;
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return {
+    selectedLevel,
+    setSelectedLevel,
+    isSaving,
+    save,
+  };
+}


### PR DESCRIPTION
## 피그마
<img width=50% alt="스크린샷 2026-01-22 오후 4 10 49" src="https://github.com/user-attachments/assets/c4627f0b-ba53-4e58-ac5d-d429e1a29a0a" />


## 작업내용

- [x] 온보딩 화면 UI 업데이트
- [x] 목표 오픽 등급 저장 훅 ```use-target-level.tsx```(AsyncStorage) 분리
- [x] 온보딩 화면 컴포넌트 분리

## 스크린샷

<img width=30% alt="simulator_screenshot_75D8BFA9-FAE6-41BB-9BD0-6698F30F85F7" src="https://github.com/user-attachments/assets/185ee0ad-16ee-4fbe-a7a5-35bb3fe79bbc" />
